### PR TITLE
[rag-alloy] Add basic ingestion endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,8 @@ APP_AUTH_MODE
 token – set to none to disable auth[16]
 APP_TOKEN
 change_me – bearer token for write endpoints
+MAX_UPLOAD_BYTES
+52_428_800 – max upload size in bytes for /ingest
 QDRANT_HOST/PORT
 localhost/6333 – vector store location
 RETRIEVAL_DEFAULT_MODE

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # rag-alloy
+
+FastAPI service with file ingestion capabilities.
+
+## API
+
+- `POST /ingest` – upload a file and receive a job identifier. Files larger than `MAX_UPLOAD_BYTES` (default 50MB) are rejected with HTTP 413.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,23 @@
+import os
+from typing import Any
+
+from fastapi import FastAPI, File, HTTPException, UploadFile
+
+MAX_UPLOAD_BYTES = int(os.environ.get("MAX_UPLOAD_BYTES", 50 * 1024 * 1024))
+
+app = FastAPI()
+
+
+@app.post("/ingest")
+async def ingest(file: UploadFile = File(...)) -> dict[str, Any]:
+    """Accept a file upload and return a job identifier placeholder.
+
+    The request is rejected with HTTP 413 when the file exceeds
+    ``MAX_UPLOAD_BYTES``.
+    """
+    file.file.seek(0, os.SEEK_END)
+    size = file.file.tell()
+    file.file.seek(0)
+    if size > MAX_UPLOAD_BYTES:
+        raise HTTPException(status_code=413, detail="File too large")
+    return {"job_id": "todo"}


### PR DESCRIPTION
## Summary
- add FastAPI skeleton with `/ingest` route and configurable upload size limit
- document ingest endpoint and MAX_UPLOAD_BYTES environment variable

## Testing
- `python -m black app/main.py`
- `python -m ruff check app/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb00d10c0483228f9e6c486c6ba55d