### PR TITLE
[rag-alloy] Add Unstructured document parser

### DIFF
--- a/ingest/parsers.py
+++ b/ingest/parsers.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+"""Document parsing utilities using Unstructured."""
+
+from importlib import import_module
+from pathlib import Path
+from typing import Callable, List, Optional
+
+from unstructured.documents.elements import Element, FigureCaption, Image, Table, Text
+
+# Mapping of file suffixes to the fully qualified partition function names.
+_PARTITIONER_NAMES = {
+    ".pdf": "unstructured.partition.pdf.partition_pdf",
+    ".docx": "unstructured.partition.docx.partition_docx",
+    ".pptx": "unstructured.partition.pptx.partition_pptx",
+    ".xlsx": "unstructured.partition.xlsx.partition_xlsx",
+    ".png": "unstructured.partition.image.partition_image",
+    ".jpg": "unstructured.partition.image.partition_image",
+    ".jpeg": "unstructured.partition.image.partition_image",
+    ".gif": "unstructured.partition.image.partition_image",
+    ".bmp": "unstructured.partition.image.partition_image",
+    ".tiff": "unstructured.partition.image.partition_image",
+    ".tif": "unstructured.partition.image.partition_image",
+}
+
+
+def _get_partitioner(suffix: str) -> Optional[Callable[..., list[Element]]]:
+    """Dynamically import the Unstructured partition function for a suffix."""
+    name = _PARTITIONER_NAMES.get(suffix)
+    if not name:
+        return None
+    module_name, func_name = name.rsplit(".", 1)
+    module = import_module(module_name)
+    return getattr(module, func_name)
+
+
+def parse_document(path: Path) -> List[Element]:
+    """Parse a document into Unstructured elements.
+
+    Parameters
+    ----------
+    path:
+        Path to the document to parse.
+
+    Returns
+    -------
+    list[Element]
+        A list of text, table, and caption elements extracted from the document.
+
+    Raises
+    ------
+    ValueError
+        If the file extension is unsupported.
+    """
+
+    suffix = path.suffix.lower()
+    partitioner = _get_partitioner(suffix)
+    if partitioner is None:
+        raise ValueError(f"Unsupported file type: {suffix}")
+
+    elements = partitioner(filename=str(path))
+    allowed = (Text, Table, FigureCaption)
+    return [el for el in elements if isinstance(el, allowed) and not isinstance(el, Image)]

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Ensure the repository root is on the Python path for module resolution during tests.
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from unstructured.documents.elements import (
+    Element,
+    FigureCaption,
+    Image,
+    Table,
+    Text,
+    Title,
+)
+
+from ingest.parsers import parse_document
+
+
+@pytest.mark.parametrize("suffix", [".pdf", ".docx", ".pptx", ".xlsx", ".png"])
+def test_parse_document_filters_elements(suffix: str) -> None:
+    """Verify that parse_document extracts only text, table and caption elements."""
+    dummy_elements: list[Element] = [
+        Text("text"),
+        Table("table"),
+        FigureCaption("caption"),
+        Title("title"),
+        Image("img"),
+    ]
+
+    with patch("ingest.parsers._get_partitioner", return_value=lambda *_, **__: dummy_elements) as mock_get:
+        result = parse_document(Path(f"doc{suffix}"))
+
+    mock_get.assert_called_once_with(suffix)
+    assert all(isinstance(el, (Text, Table, FigureCaption)) for el in result)
+    assert not any(isinstance(el, Image) for el in result)
+    assert len(result) == 4
+
+
+def test_parse_document_unsupported_extension() -> None:
+    with pytest.raises(ValueError):
+        parse_document(Path("unsupported.txt"))


### PR DESCRIPTION
## Summary
- add Unstructured-based parser supporting PDF, Office docs, spreadsheets, and images
- expose `parse_document` to return text, table, and caption elements only
- cover parser behaviour and unsupported types in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb03bb77c88322ac58cbbdd799fe82