### PR TITLE
[rag-alloy] add configurable text chunking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,10 @@ APP_TOKEN
 change_me – bearer token for write endpoints
 MAX_UPLOAD_BYTES
 52_428_800 – max upload size in bytes for /ingest
+CHUNK_SIZE
+800 – max characters per chunk during ingestion
+CHUNK_OVERLAP
+120 – number of overlapping characters between chunks
 QDRANT_HOST/PORT
 localhost/6333 – vector store location
 RETRIEVAL_DEFAULT_MODE

--- a/README.md
+++ b/README.md
@@ -5,3 +5,10 @@ FastAPI service with file ingestion capabilities.
 ## API
 
 - `POST /ingest` – upload a file and receive a job identifier. Files larger than `MAX_UPLOAD_BYTES` (default 50MB) are rejected with HTTP 413.
+
+## Configuration
+
+The ingestion pipeline respects the following environment variables:
+
+- `CHUNK_SIZE` – max characters per chunk during ingestion (default 800).
+- `CHUNK_OVERLAP` – number of overlapping characters between chunks (default 120).

--- a/ingest/chunking.py
+++ b/ingest/chunking.py
@@ -1,0 +1,33 @@
+"""Utilities for splitting text into overlapping chunks."""
+
+from __future__ import annotations
+
+import os
+from typing import List
+
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+
+DEFAULT_CHUNK_SIZE = 800
+DEFAULT_CHUNK_OVERLAP = 120
+
+
+def get_text_splitter() -> RecursiveCharacterTextSplitter:
+    """Return a ``RecursiveCharacterTextSplitter`` configured from the environment.
+
+    The ``CHUNK_SIZE`` and ``CHUNK_OVERLAP`` variables control the maximum number
+    of characters per chunk and the number of characters overlapping between
+    consecutive chunks. Defaults are 800 and 120 respectively.
+    """
+
+    chunk_size = int(os.environ.get("CHUNK_SIZE", DEFAULT_CHUNK_SIZE))
+    chunk_overlap = int(os.environ.get("CHUNK_OVERLAP", DEFAULT_CHUNK_OVERLAP))
+    return RecursiveCharacterTextSplitter(
+        chunk_size=chunk_size, chunk_overlap=chunk_overlap
+    )
+
+
+def chunk_text(text: str) -> List[str]:
+    """Split ``text`` into chunks according to the configured splitter."""
+
+    splitter = get_text_splitter()
+    return splitter.split_text(text)

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+import sys
+
+# Ensure repository root is on the Python path for imports during tests.
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ingest.chunking import chunk_text, get_text_splitter
+
+
+def test_get_text_splitter_env(monkeypatch):
+    monkeypatch.setenv("CHUNK_SIZE", "10")
+    monkeypatch.setenv("CHUNK_OVERLAP", "2")
+    splitter = get_text_splitter()
+    assert splitter._chunk_size == 10
+    assert splitter._chunk_overlap == 2
+
+
+def test_chunk_text(monkeypatch):
+    monkeypatch.setenv("CHUNK_SIZE", "10")
+    monkeypatch.setenv("CHUNK_OVERLAP", "2")
+    text = "abcdefghijk"
+    chunks = chunk_text(text)
+    assert chunks == ["abcdefghij", "ijk"]


### PR DESCRIPTION
## Summary
- add `ingest/chunking.py` using LangChain's RecursiveCharacterTextSplitter
- make chunk size and overlap configurable via `CHUNK_SIZE` and `CHUNK_OVERLAP`
- document new environment variables

## Testing
- `ruff check ingest/chunking.py tests/test_chunking.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb08862a1c8322b3cf23241d72ff67