### PR TITLE
[rag-alloy] add collection management endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ FastAPI service with file ingestion capabilities.
 ## API
 
 - `POST /ingest` – upload a file and receive a job identifier. Files larger than `MAX_UPLOAD_BYTES` (default 50MB) are rejected with HTTP 413.
+- `GET /collections/{collection}/stats` – retrieve vector and point counts for a collection.
+- `DELETE /collections/{collection}` – remove a collection and all associated vectors and metadata.
 
 ## Configuration
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,22 @@
+"""FastAPI application exposing ingestion and collection management APIs."""
+
+from __future__ import annotations
+
 import os
 from typing import Any
 
 from fastapi import FastAPI, File, HTTPException, UploadFile
+from qdrant_client import QdrantClient
 
 MAX_UPLOAD_BYTES = int(os.environ.get("MAX_UPLOAD_BYTES", 50 * 1024 * 1024))
+
+if location := os.environ.get("QDRANT_LOCATION"):
+    qdrant = QdrantClient(location=location)
+else:
+    qdrant = QdrantClient(
+        host=os.environ.get("QDRANT_HOST", "localhost"),
+        port=int(os.environ.get("QDRANT_PORT", "6333")),
+    )
 
 app = FastAPI()
 
@@ -21,3 +34,25 @@ async def ingest(file: UploadFile = File(...)) -> dict[str, Any]:
     if size > MAX_UPLOAD_BYTES:
         raise HTTPException(status_code=413, detail="File too large")
     return {"job_id": "todo"}
+
+
+@app.get("/collections/{collection}/stats")
+def collection_stats(collection: str) -> dict[str, Any]:
+    """Return basic statistics for a Qdrant ``collection``."""
+
+    existing = {c.name for c in qdrant.get_collections().collections}
+    if collection not in existing:
+        raise HTTPException(status_code=404, detail="Collection not found")
+    info = qdrant.get_collection(collection_name=collection)
+    return {"points_count": info.points_count, "vectors_count": info.vectors_count}
+
+
+@app.delete("/collections/{collection}")
+def delete_collection(collection: str) -> dict[str, Any]:
+    """Delete ``collection`` from Qdrant along with all stored data."""
+
+    existing = {c.name for c in qdrant.get_collections().collections}
+    if collection not in existing:
+        raise HTTPException(status_code=404, detail="Collection not found")
+    qdrant.delete_collection(collection_name=collection)
+    return {"status": "deleted"}

--- a/tests/test_collections_api.py
+++ b/tests/test_collections_api.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import sys
+import os
+import importlib
+
+# Ensure repo root in path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+from qdrant_client.http import models as rest
+
+
+def _reload_app():
+    os.environ["QDRANT_LOCATION"] = ":memory:"
+    import app.main as main
+    return importlib.reload(main)
+
+
+def test_collection_stats_and_delete():
+    main = _reload_app()
+    client = TestClient(main.app)
+
+    main.qdrant.recreate_collection(
+        "test", rest.VectorParams(size=2, distance=rest.Distance.COSINE)
+    )
+    main.qdrant.upsert(
+        "test",
+        points=[
+            rest.PointStruct(id=1, vector=[0.1, 0.2], payload={"text": "hello"})
+        ],
+    )
+
+    stats = client.get("/collections/test/stats")
+    assert stats.status_code == 200
+    assert stats.json()["points_count"] == 1
+
+    delete = client.delete("/collections/test")
+    assert delete.status_code == 200
+    names = {c.name for c in main.qdrant.get_collections().collections}
+    assert "test" not in names


### PR DESCRIPTION
## Summary
- implement `GET /collections/{collection}/stats` to expose Qdrant point counts
- implement `DELETE /collections/{collection}` to remove Qdrant collections and their vectors
- document new endpoints and test collection lifecycle

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb11d79a548322b4ca332074b9eaf5