### PR TITLE
[rag-alloy] add query response model and endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ Purpose: Provide a single service that ingests heterogeneous files (PDF, DOCX, P
 Modes: Retrieval can operate in semantic, lexical or hybrid mode and can optionally enrich context via lightweight graph hops[4].
 Reasoning: A LangGraph‑based reasoner coordinates retrieval and invokes tools (calculator, CSV/XLSX aggregation, date/time) before delegating generation to a local HF or Ollama model when enabled[5].
 API & UI: Exposes REST endpoints for ingestion, querying and admin; ships a minimal HTML/JS chat panel with optional graph preview[6].
+Query responses expose per-retriever scores and fused rankings via ``models/query.py``.
 Privacy & Security: Local processing by default; no network egress unless explicitly enabled. Mutating endpoints require token authentication[7][8].
 Setup Commands
 Follow these steps to bootstrap a development environment on Linux/macOS. The runtime requires Python 3.11.x; the service fails fast on other major versions[1][9].

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ FastAPI service with file ingestion capabilities.
 - `POST /ingest` – upload a file and receive a job identifier. Files larger than `MAX_UPLOAD_BYTES` (default 50MB) are rejected with HTTP 413.
 - `GET /collections/{collection}/stats` – retrieve vector and point counts for a collection.
 - `DELETE /collections/{collection}` – remove a collection and all associated vectors and metadata.
+- `POST /query` – retrieve text chunks for a query. The response includes per-retriever scores and a fused ranking.
 
 ## Configuration
 

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,1 @@
+"""Pydantic models for API requests and responses."""

--- a/models/query.py
+++ b/models/query.py
@@ -1,0 +1,37 @@
+"""Pydantic models for the ``/query`` endpoint."""
+
+from __future__ import annotations
+
+from typing import Literal, List
+
+from pydantic import BaseModel, Field
+
+
+class QueryRequest(BaseModel):
+    """Request payload for the ``/query`` endpoint."""
+
+    query: str
+    top_k: int = 5
+    mode: Literal["semantic", "lexical", "hybrid"] = "hybrid"
+
+
+class RetrieverScores(BaseModel):
+    """Per-retriever scores for a retrieved text chunk."""
+
+    semantic: float | None = None
+    lexical: float | None = None
+
+
+class RankedDocument(BaseModel):
+    """Retrieved text with fused ranking and retriever scores."""
+
+    text: str
+    rank: int
+    scores: RetrieverScores = Field(default_factory=RetrieverScores)
+
+
+class QueryResponse(BaseModel):
+    """Response model for ``/query`` containing fused ranking information."""
+
+    query: str
+    results: List[RankedDocument] = Field(default_factory=list)

--- a/tests/test_query_api.py
+++ b/tests/test_query_api.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+import sys
+import os
+import importlib
+
+# Ensure repo root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+from retriever.base import BaseRetriever
+from index.embedding_store import TextDoc
+
+
+class FakeStore:
+    def __init__(self, docs: list[str]):
+        self.docs = docs
+
+    def add_texts(self, texts, metadatas=None):
+        pass
+
+    def query(self, query: str, top_k: int = 5):
+        matches = [d for d in self.docs if query in d]
+        matches.reverse()
+        return [TextDoc(text=m, tags={}) for m in matches[:top_k]]
+
+
+def _reload_app():
+    os.environ["QDRANT_LOCATION"] = ":memory:"
+    import app.main as main
+    return importlib.reload(main)
+
+
+def test_query_returns_ranked_scores():
+    main = _reload_app()
+    corpus = ["alpha beta", "beta gamma", "gamma delta"]
+    store = FakeStore(corpus)
+    main.retriever = BaseRetriever(store, corpus)
+    client = TestClient(main.app)
+
+    res = client.post("/query", json={"query": "beta", "top_k": 2, "mode": "hybrid"})
+    assert res.status_code == 200
+    body = res.json()
+    assert len(body["results"]) == 2
+    first = body["results"][0]
+    assert first["rank"] == 1
+    assert set(first["scores"].keys()) == {"semantic", "lexical"}


### PR DESCRIPTION
## Summary
- define Pydantic QueryRequest/QueryResponse models with per-retriever scores and fused ranking
- add `/query` endpoint returning these models
- document query endpoint in README and agent guidance

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb165f27f88322a0a165b85654ba30