### PR TITLE
[rag-alloy] add citation metadata to query responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ FastAPI service with file ingestion capabilities.
 - `POST /ingest` – upload a file and receive a job identifier. Files larger than `MAX_UPLOAD_BYTES` (default 50MB) are rejected with HTTP 413.
 - `GET /collections/{collection}/stats` – retrieve vector and point counts for a collection.
 - `DELETE /collections/{collection}` – remove a collection and all associated vectors and metadata.
-- `POST /query` – retrieve text chunks for a query. The response includes per-retriever scores and a fused ranking. When `graph=true`, neighboring nodes from a NetworkX or Neo4j graph are returned based on spaCy entity extraction.
+- `POST /query` – retrieve text chunks for a query. The response includes per-retriever scores, fused ranking, and citations with `file_id`, `page`, and character `span`. When `graph=true`, neighboring nodes from a NetworkX or Neo4j graph are returned based on spaCy entity extraction.
 
 ## Configuration
 

--- a/models/query.py
+++ b/models/query.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Literal, List
+from typing import Literal, List, Tuple
 
 from pydantic import BaseModel, Field
 
@@ -24,11 +24,22 @@ class RetrieverScores(BaseModel):
 
 
 class RankedDocument(BaseModel):
-    """Retrieved text with fused ranking and retriever scores."""
+    """Retrieved text with fused ranking, metadata and retriever scores."""
 
     text: str
     rank: int
+    file_id: str
+    page: int | None = None
+    span: Tuple[int, int] | None = None
     scores: RetrieverScores = Field(default_factory=RetrieverScores)
+
+
+class Citation(BaseModel):
+    """Source location for an answer segment."""
+
+    file_id: str
+    page: int | None = None
+    span: Tuple[int, int] | None = None
 
 
 class QueryResponse(BaseModel):
@@ -36,4 +47,5 @@ class QueryResponse(BaseModel):
 
     query: str
     answer: str = ""
+    citations: List[Citation] = Field(default_factory=list)
     results: List[RankedDocument] = Field(default_factory=list)

--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from pathlib import Path
 import sys
 
 # Ensure repository root on path
@@ -10,7 +11,7 @@ import networkx as nx
 
 
 class FakeStore:
-    def __init__(self, docs: list[str]):
+    def __init__(self, docs: list[TextDoc]):
         self.docs = docs
 
     def add_texts(self, texts, metadatas=None):
@@ -18,13 +19,17 @@ class FakeStore:
 
     def query(self, query: str, top_k: int = 5):
         # naive semantic search: return docs containing the query word reversed order
-        matches = [d for d in self.docs if query in d]
+        matches = [d for d in self.docs if query in d.text]
         matches.reverse()
-        return [TextDoc(text=m, tags={}) for m in matches[:top_k]]
+        return matches[:top_k]
 
 
 def test_hybrid_rrf_fuses_results():
-    corpus = ["alpha beta", "beta gamma", "gamma delta"]
+    corpus = [
+        TextDoc(text="alpha beta", tags={"file_id": "f1"}),
+        TextDoc(text="beta gamma", tags={"file_id": "f2"}),
+        TextDoc(text="gamma delta", tags={"file_id": "f3"}),
+    ]
     store = FakeStore(corpus)
     retriever = BaseRetriever(store, corpus)
 
@@ -36,7 +41,7 @@ def test_hybrid_rrf_fuses_results():
 
 
 def test_graph_expansion_returns_neighbors():
-    corpus = ["Alice met Bob in Paris"]
+    corpus = [TextDoc(text="Alice met Bob in Paris", tags={"file_id": "f1"})]
     store = FakeStore(corpus)
     g = nx.Graph()
     g.add_edge("Alice", "Bob")


### PR DESCRIPTION
## Summary
- track file identifiers, pages, and character spans in retrieval results
- expose citation metadata in QueryResponse
- document query response citations in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb2d72a36083229d120cbb613968c5