### PR TITLE
[rag-alloy] include citation segments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Purpose: Provide a single service that ingests heterogeneous files (PDF, DOCX, P
 Modes: Retrieval can operate in semantic, lexical or hybrid mode and can optionally enrich context via lightweight graph hops[4].
 Reasoning: A LangGraph‑based reasoner coordinates retrieval and invokes tools (calculator, CSV/XLSX aggregation, date/time) before delegating generation to a local HF or Ollama model when enabled[5].
 API & UI: Exposes REST endpoints for ingestion, querying and admin; ships a minimal HTML/JS chat panel with optional graph preview[6].
-Query responses expose per-retriever scores and fused rankings via ``models/query.py``.
+Query responses expose per-retriever scores and fused rankings via ``models/query.py``. Citation objects include the cited text segment along with ``file_id``, ``page``, and character ``span``.
 Privacy & Security: Local processing by default; no network egress unless explicitly enabled. Mutating endpoints require token authentication[7][8].
 Setup Commands
 Follow these steps to bootstrap a development environment on Linux/macOS. The runtime requires Python 3.11.x; the service fails fast on other major versions[1][9].

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ FastAPI service with file ingestion capabilities.
 - `POST /ingest` – upload a file and receive a job identifier. Files larger than `MAX_UPLOAD_BYTES` (default 50MB) are rejected with HTTP 413.
 - `GET /collections/{collection}/stats` – retrieve vector and point counts for a collection.
 - `DELETE /collections/{collection}` – remove a collection and all associated vectors and metadata.
-- `POST /query` – retrieve text chunks for a query. The response includes per-retriever scores, fused ranking, and citations with `file_id`, `page`, and character `span`. When `graph=true`, neighboring nodes from a NetworkX or Neo4j graph are returned based on spaCy entity extraction.
+- `POST /query` – retrieve text chunks for a query. The response includes per-retriever scores, fused ranking, and citations with `file_id`, `page`, character `span`, and the cited text segment. When `graph=true`, neighboring nodes from a NetworkX or Neo4j graph are returned based on spaCy entity extraction.
 
 ## Configuration
 

--- a/app/main.py
+++ b/app/main.py
@@ -117,7 +117,7 @@ def query(req: QueryRequest) -> QueryResponse:
                 scores=scores,
             )
         )
-        citations.append(Citation(file_id=file_id, page=page, span=span))
+        citations.append(Citation(file_id=file_id, page=page, span=span, text=text))
 
     context = "\n\n".join(doc.text for doc in fused_docs)
     prompt = f"Context:\n{context}\n\nQuestion: {req.query}\nAnswer:"

--- a/graph/entities.py
+++ b/graph/entities.py
@@ -34,11 +34,10 @@ def _load_model() -> Language:
         _nlp = spacy.load("en_core_web_sm")
     except Exception:
         _nlp = spacy.blank("en")
-        ruler = EntityRuler(_nlp)
+        ruler = _nlp.add_pipe("entity_ruler")
         ruler.add_patterns([
             {"label": "MISC", "pattern": [{"IS_TITLE": True}]},
         ])
-        _nlp.add_pipe(ruler)
     return _nlp
 
 

--- a/models/query.py
+++ b/models/query.py
@@ -40,6 +40,7 @@ class Citation(BaseModel):
     file_id: str
     page: int | None = None
     span: Tuple[int, int] | None = None
+    text: str | None = None
 
 
 class QueryResponse(BaseModel):

--- a/tests/test_query_api.py
+++ b/tests/test_query_api.py
@@ -52,5 +52,11 @@ def test_query_returns_ranked_scores():
     first = body["results"][0]
     assert first["rank"] == 1
     assert set(first["scores"].keys()) == {"semantic", "lexical"}
-    assert "file_id" in first
-    assert body["citations"][0]["file_id"] == first["file_id"]
+    assert first["file_id"] in {"f1", "f2"}
+    assert first["page"] in {1, 2}
+    assert first["span"] == [0, 10]
+    citation = body["citations"][0]
+    assert citation["file_id"] == first["file_id"]
+    assert citation["page"] == first["page"]
+    assert citation["span"] == first["span"]
+    assert citation["text"] == first["text"]

--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -26,9 +26,9 @@ class FakeStore:
 
 def test_hybrid_rrf_fuses_results():
     corpus = [
-        TextDoc(text="alpha beta", tags={"file_id": "f1"}),
-        TextDoc(text="beta gamma", tags={"file_id": "f2"}),
-        TextDoc(text="gamma delta", tags={"file_id": "f3"}),
+        TextDoc(text="alpha beta", tags={"file_id": "f1", "page": 1, "span": [0, 10]}),
+        TextDoc(text="beta gamma", tags={"file_id": "f2", "page": 2, "span": [0, 10]}),
+        TextDoc(text="gamma delta", tags={"file_id": "f3", "page": 3, "span": [0, 10]}),
     ]
     store = FakeStore(corpus)
     retriever = BaseRetriever(store, corpus)
@@ -38,6 +38,8 @@ def test_hybrid_rrf_fuses_results():
     assert texts[0] in {"alpha beta", "beta gamma"}
     assert len(docs) == 2
     assert graph_ctx is None
+    assert docs[0].tags.get("file_id")
+    assert "page" in docs[0].tags and "span" in docs[0].tags
 
 
 def test_graph_expansion_returns_neighbors():


### PR DESCRIPTION
## Summary
- include cited text in query response citations with file and span metadata
- add tests verifying file, page and span tracking and citation text
- fix spaCy entity ruler setup for fallback model

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb2f841ee08322b2d07d1496559f4f