### PR TITLE
[rag-alloy] add health and metrics endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ FastAPI service with file ingestion capabilities.
 - `GET /collections/{collection}/stats` – retrieve vector and point counts for a collection.
 - `DELETE /collections/{collection}` – remove a collection and all associated vectors and metadata.
 - `POST /query` – retrieve text chunks for a query. The response includes per-retriever scores, fused ranking, and citations with `file_id`, `page`, character `span`, and the cited text segment. When `graph=true`, neighboring nodes from a NetworkX or Neo4j graph are returned based on spaCy entity extraction.
+- `GET /healthz` – report service health status.
+- `GET /metrics` – Prometheus metrics for the service.
 
 ## Configuration
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ starlette==0.47.3
 pydantic==2.11.7
 python-multipart==0.0.17
 httpx==0.27.2
+prometheus-fastapi-instrumentator==7.1.0
 
 # --- RAG orchestration ---
 langchain==0.3.7

--- a/tests/test_ops_endpoints.py
+++ b/tests/test_ops_endpoints.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import sys
+import os
+import importlib
+
+# Ensure repo root in path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+
+
+def _reload_app():
+    os.environ["QDRANT_LOCATION"] = ":memory:"
+    import app.main as main
+    return importlib.reload(main)
+
+
+def test_healthz_and_metrics():
+    main = _reload_app()
+    client = TestClient(main.app)
+
+    health = client.get("/healthz")
+    assert health.status_code == 200
+    assert health.json() == {"status": "ok"}
+
+    metrics = client.get("/metrics")
+    assert metrics.status_code == 200
+    assert "http_requests_total" in metrics.text


### PR DESCRIPTION
## Summary
- add `/healthz` endpoint and Prometheus metrics instrumentation
- document new operational endpoints and pin instrumentation dependency
- test health and metrics routes

## Testing
- `ruff check .` (fails: tests/test_retriever.py: F811 Redefinition of unused `Path`)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb314ab1bc83228f7eb163a3ac2d95