### PR TITLE
[rag-alloy] enforce Python 3.11 and add evaluation harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ content using a SHA-256 hash of each text chunk.
 ## Graph
 
 The `graph` package provides spaCy-powered entity extraction (`graph/entities.py`) and optional graph expansion using NetworkX or Neo4j.
+
+## Evaluation
+
+The `eval/harness.py` module computes recall@10, mean reciprocal rank (MRR),
+and p95 retrieval latency. The script reports whether the measured values meet
+the PRD targets of recall≥0.85, MRR≥0.65, and latency≤900 ms.

--- a/app/main.py
+++ b/app/main.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import os
+import sys
 from typing import Any
 
 from fastapi import FastAPI, File, HTTPException, UploadFile
 from prometheus_fastapi_instrumentator import Instrumentator
 from qdrant_client import QdrantClient
+
+if sys.version_info[:2] != (3, 11):  # pragma: no cover - defensive startup check
+    raise SystemExit("Python 3.11 is required")
 
 from models.query import (
     QueryRequest,

--- a/eval/__init__.py
+++ b/eval/__init__.py
@@ -1,0 +1,3 @@
+"""Evaluation utilities for retrieval metrics."""
+
+__all__ = ["harness"]

--- a/eval/harness.py
+++ b/eval/harness.py
@@ -1,0 +1,118 @@
+"""Evaluation harness computing recall, MRR and latency.
+
+The harness compares measured metrics against product requirement document
+(PRD) targets defined in :data:`PRD_TARGETS`.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Sequence, Tuple
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+PRD_TARGETS = {
+    "recall_at_10": 0.85,
+    "mrr": 0.65,
+    "p95_latency_ms": 900.0,
+}
+
+
+@dataclass
+class EvalResult:
+    """Container for evaluation metrics."""
+
+    recall_at_10: float
+    mrr: float
+    p95_latency_ms: float
+
+
+def evaluate(
+    retriever: any,
+    dataset: Sequence[Tuple[str, str]],
+    *,
+    top_k: int = 10,
+) -> EvalResult:
+    """Evaluate ``retriever`` over ``dataset``.
+
+    Parameters
+    ----------
+    retriever:
+        Object exposing ``retrieve(query, top_k, mode)``.
+    dataset:
+        Sequence of ``(query, relevant_id)`` pairs.
+    top_k:
+        Number of documents to retrieve per query.
+    """
+
+    hits = 0
+    rr_total = 0.0
+    latencies: list[float] = []
+    for query, rel_id in dataset:
+        start = time.perf_counter()
+        docs, _ = retriever.retrieve(query, top_k=top_k, mode="hybrid")
+        latencies.append((time.perf_counter() - start) * 1000)
+        ids = [d.tags.get("file_id") for d in docs]
+        if rel_id in ids:
+            hits += 1
+            rank = ids.index(rel_id) + 1
+            rr_total += 1 / rank
+    recall = hits / len(dataset) if dataset else 0.0
+    mrr = rr_total / len(dataset) if dataset else 0.0
+    if latencies:
+        latencies.sort()
+        idx = max(int(0.95 * len(latencies)) - 1, 0)
+        p95 = latencies[idx]
+    else:
+        p95 = 0.0
+    return EvalResult(recall, mrr, p95)
+
+
+def meets_prd_targets(result: EvalResult) -> bool:
+    """Return ``True`` when ``result`` satisfies :data:`PRD_TARGETS`."""
+
+    return (
+        result.recall_at_10 >= PRD_TARGETS["recall_at_10"]
+        and result.mrr >= PRD_TARGETS["mrr"]
+        and result.p95_latency_ms <= PRD_TARGETS["p95_latency_ms"]
+    )
+
+
+if __name__ == "__main__":
+    # Minimal demonstration using an in-memory retriever.
+    from index.embedding_store import TextDoc
+
+    class FakeStore:
+        def __init__(self, docs: list[TextDoc]):
+            self.docs = docs
+
+        def add_texts(self, texts, metadatas=None):
+            pass
+
+        def query(self, query: str, top_k: int = 5):
+            matches = [d for d in self.docs if query in d.text]
+            matches.reverse()
+            return matches[:top_k]
+
+    class DummyRetriever:
+        def __init__(self, store: FakeStore):
+            self.store = store
+
+        def retrieve(self, query: str, top_k: int = 5, mode: str = "hybrid"):
+            docs = self.store.query(query, top_k)
+            return docs, None
+
+    corpus = [
+        TextDoc(text="alpha beta", tags={"file_id": "f1"}),
+        TextDoc(text="beta gamma", tags={"file_id": "f2"}),
+        TextDoc(text="gamma delta", tags={"file_id": "f3"}),
+    ]
+    store = FakeStore(corpus)
+    retriever = DummyRetriever(store)
+    dataset = [("beta", "f1"), ("gamma", "f3")]
+    result = evaluate(retriever, dataset, top_k=2)
+    print(result)
+    print("Meets targets:", meets_prd_targets(result))

--- a/tests/test_eval_harness.py
+++ b/tests/test_eval_harness.py
@@ -1,0 +1,49 @@
+import importlib.util
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from index.embedding_store import TextDoc
+from retriever.base import BaseRetriever
+
+
+spec = importlib.util.spec_from_file_location(
+    "eval.harness", Path(__file__).resolve().parents[1] / "eval" / "harness.py"
+)
+harness = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = harness
+spec.loader.exec_module(harness)
+EvalResult = harness.EvalResult
+evaluate = harness.evaluate
+meets_prd_targets = harness.meets_prd_targets
+
+
+class FakeStore:
+    def __init__(self, docs: list[TextDoc]):
+        self.docs = docs
+
+    def add_texts(self, texts, metadatas=None):
+        pass
+
+    def query(self, query: str, top_k: int = 5):
+        matches = [d for d in self.docs if query in d.text]
+        matches.reverse()
+        return matches[:top_k]
+
+
+def test_evaluate_returns_metrics():
+    corpus = [
+        TextDoc(text="alpha beta", tags={"file_id": "f1"}),
+        TextDoc(text="beta gamma", tags={"file_id": "f2"}),
+        TextDoc(text="gamma delta", tags={"file_id": "f3"}),
+    ]
+    store = FakeStore(corpus)
+    retriever = BaseRetriever(store, corpus)
+    dataset = [("beta", "f1"), ("gamma", "f3")]
+    result = evaluate(retriever, dataset, top_k=2)
+    assert result.recall_at_10 == 1.0
+    assert 0 < result.mrr <= 1
+    assert result.p95_latency_ms >= 0
+    assert not meets_prd_targets(result)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,17 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def test_exit_when_python_not_311(monkeypatch):
+    """Importing the service on non-3.11 versions exits immediately."""
+    module = "app.main"
+    sys.modules.pop(module, None)
+    monkeypatch.setattr(sys, "version_info", (3, 10, 0))
+    with pytest.raises(SystemExit):
+        importlib.import_module(module)
+    sys.modules.pop(module, None)


### PR DESCRIPTION
## Summary
- exit at startup unless running under Python 3.11
- scaffold evaluation harness for recall, MRR and latency
- document evaluation targets and add tests for version check and harness

## Testing
- `python eval/harness.py`
- `pytest tests/test_version.py -q`
- `pytest tests/test_eval_harness.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb3398162c8322bb8c044d4e1d09cb