### PR TITLE
[rag-alloy] add ingestion job status tracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Project Overview
 Purpose: Provide a single service that ingests heterogeneous files (PDF, DOCX, PPTX, XLSX, images), builds semantic/lexical indices and an optional knowledge graph, and answers questions with citations[3].
 Modes: Retrieval can operate in semantic, lexical or hybrid mode and can optionally enrich context via lightweight graph hops[4].
 Reasoning: A LangGraph‑based reasoner coordinates retrieval and invokes tools (calculator, CSV/XLSX aggregation, date/time) before delegating generation to a local HF or Ollama model when enabled[5].
-API & UI: Exposes REST endpoints for ingestion, querying and admin; ships a minimal HTML/JS chat panel with optional graph preview[6].
+API & UI: Exposes REST endpoints for ingestion, job status retrieval, querying and admin; ships a minimal HTML/JS chat panel with optional graph preview[6].
 Query responses expose per-retriever scores and fused rankings via ``models/query.py``. Citation objects include the cited text segment along with ``file_id``, ``page``, and character ``span``.
 Privacy & Security: Local processing by default; no network egress unless explicitly enabled. Mutating endpoints require token authentication[7][8].
 Setup Commands

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ FastAPI service with file ingestion capabilities.
 ## API
 
 - `POST /ingest` – upload a file and receive a job identifier. Files larger than `MAX_UPLOAD_BYTES` (default 50MB) are rejected with HTTP 413. Re-uploading an identical file returns the existing job ID without reprocessing.
+- `GET /ingest/{job_id}` – retrieve status and artifact metadata for an ingestion job.
 - `GET /collections/{collection}/stats` – retrieve vector and point counts for a collection.
 - `DELETE /collections/{collection}` – remove a collection and all associated vectors and metadata.
 - `POST /query` – retrieve text chunks for a query. The response includes per-retriever scores, fused ranking, and citations with `file_id`, `page`, character `span`, and the cited text segment. When `graph=true`, neighboring nodes from a NetworkX or Neo4j graph are returned based on spaCy entity extraction.

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,1 +1,20 @@
 """Pydantic models for API requests and responses."""
+
+from .job import Artifact, JobStatus
+from .query import (
+    QueryRequest,
+    QueryResponse,
+    RankedDocument,
+    Citation,
+    RetrieverScores,
+)
+
+__all__ = [
+    "Artifact",
+    "JobStatus",
+    "QueryRequest",
+    "QueryResponse",
+    "RankedDocument",
+    "Citation",
+    "RetrieverScores",
+]

--- a/models/job.py
+++ b/models/job.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+"""Pydantic models representing ingestion job metadata."""
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class Artifact(BaseModel):
+    """Metadata about an ingested file artifact."""
+
+    file_id: str
+    pages: int
+    chunks: int
+
+
+class JobStatus(BaseModel):
+    """Status metadata for an ingestion job."""
+
+    status: Literal["pending", "processing", "done", "error"]
+    started_at: datetime
+    ended_at: datetime | None = None
+    duration_ms: int | None = None
+    artifacts: list[Artifact] = Field(default_factory=list)


### PR DESCRIPTION
## Summary
- add `JobStatus` pydantic model and persist job metadata during ingestion
- expose `GET /ingest/{job_id}` to retrieve job status and artifacts
- document new endpoint and adjust tests

## Testing
- `make test` *(fails: pdf2image.exceptions.PDFPageCountError)*

------
https://chatgpt.com/codex/tasks/task_e_68bb84f90e0883229c7ed343ed3b1792