### PR TITLE
[rag-alloy] dedupe chunk storage via add_texts

### DIFF
--- a/retriever/base.py
+++ b/retriever/base.py
@@ -68,8 +68,16 @@ class BaseRetriever:
         new_docs = list(docs)
         if not new_docs:
             return
-        self.corpus.extend(new_docs)
-        self.store.add_texts([d.text for d in new_docs], [d.tags for d in new_docs])
+        ids = self.store.add_texts([d.text for d in new_docs], [d.tags for d in new_docs])
+        inserted: List[TextDoc] = []
+        id_set = set(ids)
+        for doc in new_docs:
+            uid = self.store._sha256(doc.text)[:32]
+            if uid in id_set:
+                inserted.append(doc)
+        if not inserted:
+            return
+        self.corpus.extend(inserted)
         tokenized = [c.text.split() for c in self.corpus]
         self.bm25 = BM25Okapi(tokenized)
 


### PR DESCRIPTION
## Summary
- Skip duplicate chunks by using `EmbeddingStore.add_texts` and counting only new IDs during ingestion.
- Filter BaseRetriever corpus to exclude documents whose IDs already exist.
- Add parser fallbacks for missing Unstructured partitioners and expand tests for duplicate handling.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb9d0455548322a7b3452ef3a31996